### PR TITLE
fix(#33): PHP 8.1 update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-apache
+FROM php:8.1-apache
 WORKDIR /var/www/html
 
 COPY WebApp .

--- a/WebApp/_header.php
+++ b/WebApp/_header.php
@@ -43,6 +43,7 @@
     </head>
 
 <?php
+    global $s_page_title;
     $page_header_title = various::getPageName($s_page_title);
 ?>
 

--- a/WebApp/functions_security.php
+++ b/WebApp/functions_security.php
@@ -35,7 +35,7 @@ class security
                 {return com_create_guid();}
             else
                 {
-                    mt_srand((double)microtime()*10000);
+                    mt_srand((int)microtime()*10000);
                     $charid = strtoupper(md5(uniqid(rand(), true)));
                     $hyphen = chr(45);// "-"
                     $uuid = chr(123)// "{"

--- a/WebApp/functions_various.php
+++ b/WebApp/functions_various.php
@@ -85,7 +85,7 @@ class various
      */
     public static function getPageUrl() : String
     {
-        $page_addr = $_SERVER['DOCUMENT_URI'];
+        $page_addr = $_SERVER['REQUEST_URI'];
         $page_url = (substr(trim($page_addr, '/'), 0, strpos($page_addr, '.')-1));
         return $page_url;
     }


### PR DESCRIPTION
Fixed errors & deprecated function calls in order to update to PHP 8.1 as 7.4 is no longer receiving security updates.